### PR TITLE
Remove process.env dependency

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ Install the package using NPM or Yarn:
         # or
         # yarn add react-mixpanel-browser
 
-Add your Mixpanel token to `./.env`:
-
-        REACT_APP_MIXPANEL_TOKEN=<token>
-
 ## Usage
 
 ### `MixpanelProvider` Component
@@ -24,7 +20,7 @@ Add your Mixpanel token to `./.env`:
     import { MixpanelProvider } from 'react-mixpanel-browser';
 
     const App = (props) => (
-      <MixpanelProvider>
+      <MixpanelProvider token="<token>">
         ...
       </MixpanelProvider>
     );

--- a/dist/cjs.js
+++ b/dist/cjs.js
@@ -32,7 +32,7 @@ const MixpanelProvider = ({
   token
 }) => {
   config = Object.assign({}, defaults, config);
-  mixpanel__default["default"].init(token || process.env.REACT_APP_MIXPANEL_TOKEN, config, name);
+  mixpanel__default["default"].init(token, config, name);
   return /*#__PURE__*/React__default["default"].createElement(Provider, {
     value: mixpanel__default["default"]
   }, children);

--- a/dist/es.js
+++ b/dist/es.js
@@ -22,7 +22,7 @@ const MixpanelProvider = ({
   token
 }) => {
   config = Object.assign({}, defaults, config);
-  mixpanel.init(token || process.env.REACT_APP_MIXPANEL_TOKEN, config, name);
+  mixpanel.init(token, config, name);
   return /*#__PURE__*/React.createElement(Provider, {
     value: mixpanel
   }, children);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mixpanel-browser",
-  "version": "3.2.2",
+  "version": "4.0.0",
   "description": "React providers for mixpanel-browser using the Context API.",
   "keywords": [
     "react",

--- a/src/MixpanelProvider.jsx
+++ b/src/MixpanelProvider.jsx
@@ -7,17 +7,11 @@ const defaults = {
 };
 
 const MixpanelProvider = ({ children, config, name, token }) => {
-
   config = Object.assign({}, defaults, config);
 
-  mixpanel.init(token || process.env.REACT_APP_MIXPANEL_TOKEN, config, name);
+  mixpanel.init(token, config, name);
 
-  return (
-    <Provider value={mixpanel}>
-      {children}
-    </Provider>
-  );
-
+  return <Provider value={mixpanel}>{children}</Provider>;
 };
 
 export default MixpanelProvider;


### PR DESCRIPTION
Currently this package depends on the `process.env` not being undefined at build time, which fails on some build systems. (like [Vite](https://vitejs.dev/)) This pull request removes the logic that grabs `process.env.REACT_APP_MIXPANEL_TOKEN` and assumes it will always be provided as a `MixpanelProvider` prop.

As this would be a breaking change for anyone that uses this package and doesn't provide `token` explicitly, I bumped the major version of the package.

I added a basic `.prettierrc` config, as it looks like the package was using single quote characters, and most modern editors default to double quotes. 

I understand the change may be a little controversial if you're not planning on supporting any other build systems, in which case feel free to close this PR. (and we'll continue using the package based on our fork)

