### PR TITLE
Remove husky from postinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Wrapper of [mixpanel-browser](https://www.npmjs.com/package/mixpanel-browser) fo
 
 Provides a `Mixpanel` instance via the context API.
 
+If you would like to contribute, please run e.g. `npm husky install` after cloning the repo to install hooks.
+
 ## Installation
 
 ### NPM

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
   "scripts": {
     "build": "rimraf ./dist && yarn exec ./bin/build.ts",
     "lint": "eslint --ext \".cjs,.mjs,.js,.jsx,.ts,.tsx\" --fix .",
-    "postinstall": "husky install",
     "postrelease": "TAG=$(yarn exec 'echo $npm_package_version') git commit -am \"${TAG}\" && git tag -a \"${TAG}\" -m \"${TAG}\" && git push --follow-tags && yarn npm publish",
     "prepack": "yarn run build",
     "release:major": "yarn version major && yarn run postrelease",


### PR DESCRIPTION
I was running into an issue with this package trying to install husky hooks after `pnpm install`. I've removed that `postinstall` script and added a section to the README.