### PR TITLE
Adjust import style for mixpanel-browser

### DIFF
--- a/src/MixpanelProvider.tsx
+++ b/src/MixpanelProvider.tsx
@@ -1,6 +1,9 @@
-import { type Config, init } from 'mixpanel-browser';
+import * as MixpanelBrowser from 'mixpanel-browser';
 import { type ProviderProps, useMemo } from 'react';
 import { type MixpanelContext, mixpanelContext } from './mixpanelContext.js';
+
+type Config = MixpanelBrowser.Config;
+const { init } = MixpanelBrowser;
 
 export interface MixpanelProviderProps extends Omit<ProviderProps<MixpanelContext>, 'value'> {
   config?: Partial<Config>;


### PR DESCRIPTION
### Problem:
When using the `<MixpanelProvider>` the following error occurs:
```
SyntaxError: Named export 'init' not found. The requested module 'mixpanel-browser' is a CommonJS module, which may not support all module.exports as named exports.
```

### Proposed Solution:
I believe the issue stems from the way the `mixpanel-browser` package is being imported. I've adjusted the import style in the code to address this problem and ensure compatibility.

Please review the changes and let me know if any further adjustments are needed.
